### PR TITLE
Fix for Windows

### DIFF
--- a/src/facade.ts
+++ b/src/facade.ts
@@ -121,7 +121,10 @@ export class Facade {
     }
 
     return Array.from(this.rootPaths)
-      .map(v => filePath.match(v))
+      .map(v => {
+          const regRep = new RegExp(v.replace(/([.*+?^=!:${}()|[\]\/\\])/g, '\\$1'))
+          return filePath.match(regRep)
+      })
       .filter(v => !!v)[0][0]
   }
 

--- a/src/renderers/inquirer-renderer.ts
+++ b/src/renderers/inquirer-renderer.ts
@@ -146,7 +146,7 @@ export class InquirerRenderer extends AbstractRenderer {
       .map(cls => {
         const absPath = this.treeWithMap.pathMap.get(cls)
         const path    = (() => {
-          const tmp1 = pathModule.relative(baseDirPath, absPath)
+          const tmp1 = pathModule.relative(baseDirPath, absPath).replace(/\\/g, pathModule.posix.sep)
           return /^\./.test(tmp1) ? tmp1 : `./${tmp1}`
         })()
         return `import { ${cls} } from '${path}';`
@@ -168,7 +168,7 @@ export class InquirerRenderer extends AbstractRenderer {
             new RegExp(this.options.mockPathPattern),
             this.options.mockPathReplacement,
           )
-          return [pathModule.dirname(tmp2), replaced].join(pathModule.sep)
+          return [pathModule.dirname(tmp2), replaced].join(pathModule.posix.sep)
         })()
 
         return `import { ${cls}Mock } from '${path}';`


### PR DESCRIPTION
I fixed two problems. The first is that the path separator is backslash on Windows so it will be outputted as a slash. The second fixes the problem of failing the test on Windows.

**on command prompt**
```
$ testbedder src\app\dashboard\dashboard.component.ts
? Which module do you use as real? DashboardComponent, └── HeroService
? Which module do you use as real? Done, DashboardComponent
import { DashboardComponent } from './dashboard.component';
import { HeroService } from '..\hero.service';
import { HeroServiceMock } from '..\hero.service.mock';

DashboardComponent,
{provide: HeroService, useClass: HeroServiceMock},
```

**my environment:**

**OS:**
Windows10
**Node.js version:**
6.10.0
